### PR TITLE
Streamline styling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ const AppWrapper = styled.div`
   position: relative;
   overflow: hidden;
   
-  /* Background texture inspired by 2006 web design but with modern implementation */
+  /* Soft background accents */
   &::before {
     content: '';
     position: absolute;
@@ -29,9 +29,9 @@ const AppWrapper = styled.div`
     left: 0;
     right: 0;
     bottom: 0;
-    background-image: 
-      radial-gradient(circle at 20% 30%, rgba(255, 87, 34, 0.1) 0%, transparent 300px),
-      radial-gradient(circle at 80% 80%, rgba(38, 166, 154, 0.1) 0%, transparent 400px);
+    background-image:
+      radial-gradient(circle at 20% 30%, rgba(255, 87, 34, 0.05) 0%, transparent 200px),
+      radial-gradient(circle at 80% 80%, rgba(38, 166, 154, 0.05) 0%, transparent 300px);
     z-index: -1;
   }
 `;

--- a/src/components/layout/Sidebar.js
+++ b/src/components/layout/Sidebar.js
@@ -47,7 +47,7 @@ const LogoContainer = styled.div`
     color: white;
     margin: 0;
     letter-spacing: 1px;
-    text-shadow: 2px 2px 0 rgba(0, 0, 0, 0.1);
+    text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.1);
   }
 `;
 

--- a/src/components/ui/Button.js
+++ b/src/components/ui/Button.js
@@ -25,17 +25,6 @@ const BaseButtonStyles = css`
   position: relative;
   overflow: hidden;
   
-  /* Subtle texture for a nostalgic feel */
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-image: url("data:image/svg+xml,%3Csvg width='40' height='40' viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23ffffff' fill-opacity='0.05' fill-rule='evenodd'%3E%3Cpath d='M0 38.59l2.83-2.83 1.41 1.41L1.41 40H0v-1.41zM0 20v-1.41l1.41-1.41L4.24 20H0zm0-18.59l2.83 2.83 1.41-1.41L1.41 0H0v1.41zM20 0v4.24l2.83-2.83L24.24 0H20zm18.59 0l-2.83 2.83-1.41-1.41L37.17 0H40v1.41zM40 20h-4.24l2.83 2.83L40 21.41V20zm0 18.59l-2.83-2.83-1.41 1.41L37.17 40H40v-1.41zM20 40v-4.24l-2.83 2.83L15.76 40H20zm-18.59 0l2.83-2.83 1.41 1.41L2.83 40H0v-1.41z'/%3E%3C/g%3E%3C/svg%3E");
-    pointer-events: none;
-  }
 
   /* Subtle outline for depth */
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);

--- a/src/pages/NotFound.js
+++ b/src/pages/NotFound.js
@@ -12,10 +12,10 @@ const NotFoundContainer = styled.div`
 `;
 
 const Title = styled.h1`
-  font-size: 8rem;
+  font-size: 7rem;
   margin-bottom: ${({ theme }) => theme.spacing.md};
   color: ${({ theme }) => theme.colors.primary};
-  text-shadow: 2px 2px 0 rgba(0, 0, 0, 0.1);
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.1);
   
   @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
     font-size: 6rem;

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -19,8 +19,6 @@ const GlobalStyles = createGlobalStyle`
     line-height: 1.6;
     color: ${({ theme }) => theme.colors.text};
     background-color: ${({ theme }) => theme.colors.background};
-    /* Subtle texture background for nostalgic feel */
-    background-image: url("data:image/svg+xml,%3Csvg width='100' height='100' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 18c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm48 25c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm-43-7c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm63 31c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM34 90c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm56-76c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM12 86c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm28-65c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm23-11c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-6 60c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm29 22c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zM32 63c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm57-13c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-9-21c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM60 91c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM35 41c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM12 60c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2z' fill='${({ theme }) => theme.colors.primaryDark.replace('#', '%23')}' fill-opacity='0.03' fill-rule='evenodd'/%3E%3C/svg%3E");
   }
   
   /* Typography */
@@ -30,20 +28,18 @@ const GlobalStyles = createGlobalStyle`
     font-weight: 700;
     line-height: 1.2;
     margin-bottom: ${({ theme }) => theme.spacing.md};
-    /* Subtle text-shadow for nostalgic feel */
-    text-shadow: 1px 1px 0 rgba(255, 255, 255, 0.5);
   }
   
   h1 {
-    font-size: 3.6rem;
+    font-size: 3.2rem;
   }
   
   h2 {
-    font-size: 3rem;
+    font-size: 2.6rem;
   }
   
   h3 {
-    font-size: 2.4rem;
+    font-size: 2.2rem;
   }
   
   h4 {
@@ -116,24 +112,9 @@ const GlobalStyles = createGlobalStyle`
     100% { transform: scale(1); }
   }
   
-  /* Custom scrollbar for a 2006-inspired touch */
+  /* Minimal custom scrollbar */
   ::-webkit-scrollbar {
-    width: 12px;
-  }
-  
-  ::-webkit-scrollbar-track {
-    background: ${({ theme }) => theme.colors.cardBackground};
-    border-radius: ${({ theme }) => theme.borderRadius.small};
-  }
-  
-  ::-webkit-scrollbar-thumb {
-    background-color: ${({ theme }) => theme.colors.primary};
-    border-radius: ${({ theme }) => theme.borderRadius.small};
-    border: 3px solid ${({ theme }) => theme.colors.cardBackground};
-  }
-  
-  ::-webkit-scrollbar-thumb:hover {
-    background-color: ${({ theme }) => theme.colors.primaryDark};
+    width: 8px;
   }
 `;
 


### PR DESCRIPTION
## Summary
- trim texture from global body background
- soften App background gradients
- remove button noise overlay
- reduce heading sizes and tweak text shadows
- use a minimal scrollbar style
- lighten heavy text-shadows on pages

## Testing
- `npm test` *(fails: jest not found)*