### PR TITLE
Add static asset handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@babel/preset-react": "^7.22.3",
     "babel-loader": "^9.1.2",
     "clean-webpack-plugin": "^4.0.0",
+    "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.8.1",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.5.1",

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,0 +1,4 @@
+/* Placeholder styles */
+body {
+  font-family: 'Roboto', sans-serif;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = {
   entry: './src/index.js',
@@ -54,9 +55,19 @@ module.exports = {
   },
   plugins: [
     new CleanWebpackPlugin(),
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: path.resolve(__dirname, 'public'),
+          to: path.resolve(__dirname, 'dist'),
+          globOptions: {
+            ignore: ['**/index.html']
+          }
+        }
+      ]
+    }),
     new HtmlWebpackPlugin({
       template: './public/index.html'
-      // favicon will be added later
     })
   ],
   devServer: {


### PR DESCRIPTION
## Summary
- provide placeholder `styles.css` and copy the favicon
- ensure webpack copies assets from `public`
- include CopyWebpackPlugin dependency

## Testing
- `npm test`
- `npm run build`
