### PR TITLE
Switch avatars to <img> with alt text

### DIFF
--- a/src/components/layout/Sidebar.js
+++ b/src/components/layout/Sidebar.js
@@ -66,12 +66,17 @@ const Avatar = styled.div`
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  background-image: url(${props => props.src});
-  background-size: cover;
-  background-position: center;
+  overflow: hidden;
   margin-bottom: ${({ theme }) => theme.spacing.sm};
   border: 3px solid ${({ theme }) => theme.colors.primary};
   box-shadow: ${({ theme }) => theme.shadows.medium};
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
 `;
 
 const Username = styled.h2`
@@ -201,7 +206,9 @@ function Sidebar({ userProfile }) {
         </LogoContainer>
         
         <UserSection>
-          <Avatar src={userProfile.avatarUrl} />
+          <Avatar>
+            <img src={userProfile.avatarUrl} alt={`${userProfile.name}'s avatar`} />
+          </Avatar>
           <Username>{userProfile.name}</Username>
           <MembershipLevel>{userProfile.membershipLevel}</MembershipLevel>
         </UserSection>

--- a/src/pages/Account.js
+++ b/src/pages/Account.js
@@ -58,13 +58,18 @@ const ProfileAvatar = styled.div`
   width: 150px;
   height: 150px;
   border-radius: 50%;
-  background-image: url(${props => props.src});
-  background-size: cover;
-  background-position: center;
+  overflow: hidden;
   margin-bottom: ${({ theme }) => theme.spacing.lg};
   border: 4px solid ${({ theme }) => theme.colors.primary};
   box-shadow: ${({ theme }) => theme.shadows.medium};
   position: relative;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
   
   @media (min-width: ${({ theme }) => theme.breakpoints.md}) {
     margin-bottom: 0;
@@ -906,7 +911,8 @@ function Account({ userProfile }) {
           <>
             <motion.div variants={fadeInUp}>
               <ProfileCard>
-                <ProfileAvatar src={userProfile.avatarUrl}>
+                <ProfileAvatar>
+                  <img src={userProfile.avatarUrl} alt={`${userProfile.name}'s avatar`} />
                   <EditAvatarOverlay className="edit-overlay">Change Photo</EditAvatarOverlay>
                 </ProfileAvatar>
                 <ProfileInfo>

--- a/src/pages/CommunityHub.js
+++ b/src/pages/CommunityHub.js
@@ -258,12 +258,17 @@ const DonorAvatar = styled.div`
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  background-image: url(${props => props.src});
-  background-size: cover;
-  background-position: center;
+  overflow: hidden;
   margin-bottom: ${({ theme }) => theme.spacing.sm};
   border: 3px solid ${({ theme }) => theme.colors.primary};
   box-shadow: ${({ theme }) => theme.shadows.small};
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
 `;
 
 const DonorName = styled.div`
@@ -595,7 +600,9 @@ function CommunityHub() {
           <DonorsGrid>
             {recentDonors.map(donor => (
               <DonorItem key={donor.id}>
-                <DonorAvatar src={donor.avatar} />
+                <DonorAvatar>
+                  <img src={donor.avatar} alt={`${donor.name}'s avatar`} />
+                </DonorAvatar>
                 <DonorName>{donor.name}</DonorName>
                 <DonorThankYou>Thanks for {donor.amount}!</DonorThankYou>
               </DonorItem>

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -397,11 +397,16 @@ const ShoutoutAvatar = styled.div`
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  background-image: url(${props => props.src});
-  background-size: cover;
-  background-position: center;
+  overflow: hidden;
   margin-right: ${({ theme }) => theme.spacing.xs};
   border: 2px solid ${({ theme }) => theme.colors.primary};
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
 `;
 
 const ShoutoutText = styled.p`
@@ -662,7 +667,9 @@ function Dashboard({ userProfile }) {
             <ShoutoutContainer>
               {recentDonors.map(donor => (
                 <ShoutoutItem key={donor.id}>
-                  <ShoutoutAvatar src={donor.avatar} />
+                  <ShoutoutAvatar>
+                    <img src={donor.avatar} alt={`${donor.name}'s avatar`} />
+                  </ShoutoutAvatar>
                   <ShoutoutText>{donor.name}, thanks!</ShoutoutText>
                 </ShoutoutItem>
               ))}


### PR DESCRIPTION
## Summary
- use `<img>` inside the sidebar avatar
- update account, dashboard and community hub avatar components
- add meaningful `alt` text for accessibility

## Testing
- `npm test`